### PR TITLE
Recover when unreleased tag does not exist

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,5 +30,5 @@ deployment:
     branch: master
     owner: sgerrand
     commands:
-      - ghr -u sgerrand --prerelease --delete unreleased packages
+      - ghr -u sgerrand --prerelease --delete unreleased packages || return 0
       - ghr -u sgerrand --prerelease unreleased packages/builder/x86_64


### PR DESCRIPTION
:information_desk_person: When `ghr` is used with the `--delete` flag and the supplied tag does not exist, it exists with a failure code and fails the build. This error should be recoverable.

```
ghr -u sgerrand --prerelease --delete unreleased packages
DELETE https://api.github.com/repos/sgerrand/alpine-pkg-makeself/git/refs/tags/unreleased: 422 Reference does not exist []
ghr -u sgerrand --prerelease --delete unreleased packages returned exit code 11

Action failed: ghr -u sgerrand --prerelease --delete unreleased packages
```
